### PR TITLE
Add sstable-stats.py

### DIFF
--- a/sstable-compressioninfo.py
+++ b/sstable-compressioninfo.py
@@ -21,7 +21,7 @@ for fname in args.compressioninfo_file:
     options = s.map32()
     chunk_size = s.int32()
     data_len = s.int64()
-    offsets = s.array32(s.int64)
+    offsets = s.array32(sstablelib.Stream.int64)
     end = offsets[1:] + [offsets[-1]]
     diffs = list(itertools.starmap(operator.__sub__, zip(end, offsets)))
     avg_chunk = int(statistics.mean(diffs[:-1]))

--- a/sstable-statistics.py
+++ b/sstable-statistics.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import struct
+import sstablelib
+
+METADATA_TYPE_TO_NAME = {
+    0: "Validation",
+    1: "Compaction",
+    2: "Stats",
+    3: "Serialization",
+}
+
+
+def read_validation(stream, fmt):
+    return sstablelib.parse(
+        stream,
+        (
+            ('partitioner', sstablelib.Stream.string16),
+            ('filter_chance', sstablelib.Stream.double),
+        )
+    )
+
+
+def read_compaction(stream, fmt):
+    ka_la_schema = (
+        ('cardinality', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.uint8)),
+    )
+    mc_schema = (
+        ('ancestors', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.uint32)),
+        ('cardinality', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.uint8)),
+    )
+
+    if fmt == 'mc':
+        return sstablelib.parse(stream, mc_schema)
+    else:
+        return sstablelib.parse(stream, ka_la_schema)
+
+
+def read_stats(stream, fmt):
+    replay_position = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('id', sstablelib.Stream.uint64),
+        ('pos', sstablelib.Stream.uint32),
+    )
+    estimated_histogram = sstablelib.Stream.instantiate(
+        sstablelib.Stream.array32,
+        sstablelib.Stream.instantiate(
+            sstablelib.Stream.struct,
+            ('offset', sstablelib.Stream.uint64),
+            ('bucket', sstablelib.Stream.uint64),
+        ),
+    )
+    streaming_histogram = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('max_bin_size', sstablelib.Stream.uint32),
+        ('elements', sstablelib.Stream.instantiate(
+            sstablelib.Stream.array32,
+            sstablelib.Stream.instantiate(
+                sstablelib.Stream.struct,
+                ('key', sstablelib.Stream.double),
+                ('value', sstablelib.Stream.uint64),
+            ),
+        )),
+    )
+    commitlog_interval = sstablelib.Stream.instantiate(
+        sstablelib.Stream.tuple,
+        replay_position,
+        replay_position,
+    )
+
+    ka_la_schema = (
+        ('estimated_partition_size', estimated_histogram),
+        ('estimated_cells_count', estimated_histogram),
+        ('position', replay_position),
+        ('min_timestamp', sstablelib.Stream.int64),
+        ('max_timestamp', sstablelib.Stream.int64),
+        ('max_local_deletion_time', sstablelib.Stream.int32),
+        ('compression_ratio', sstablelib.Stream.double),
+        ('estimated_tombstone_drop_time', streaming_histogram),
+        ('sstable_level', sstablelib.Stream.uint32),
+        ('repaired_at', sstablelib.Stream.uint64),
+        ('min_column_names', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.string16)),
+        ('max_column_names', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.string16)),
+        ('has_legacy_counter_shards', sstablelib.Stream.bool),
+    )
+
+    mc_schema = (
+        ('estimated_partition_size', estimated_histogram),
+        ('estimated_cells_count', estimated_histogram),
+        ('position', replay_position),
+        ('min_timestamp', sstablelib.Stream.int64),
+        ('max_timestamp', sstablelib.Stream.int64),
+        ('min_local_deletion_time', sstablelib.Stream.int32),
+        ('max_local_deletion_time', sstablelib.Stream.int32),
+        ('min_ttl', sstablelib.Stream.int32),
+        ('max_ttl', sstablelib.Stream.int32),
+        ('compression_ratio', sstablelib.Stream.double),
+        ('estimated_tombstone_drop_time', streaming_histogram),
+        ('sstable_level', sstablelib.Stream.uint32),
+        ('repaired_at', sstablelib.Stream.uint64),
+        ('min_column_names', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.string16)),
+        ('max_column_names', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.string16)),
+        ('has_legacy_counter_shards', sstablelib.Stream.bool),
+        ('columns_count', sstablelib.Stream.int64),
+        ('rows_count', sstablelib.Stream.int64),
+        ('commitlog_lower_bound', replay_position),
+        ('commitlog_intervals', sstablelib.Stream.instantiate(sstablelib.Stream.array32, commitlog_interval)),
+    )
+
+    if fmt == 'mc':
+        return sstablelib.parse(stream, mc_schema)
+    else:
+        return sstablelib.parse(stream, ka_la_schema)
+
+
+def read_serialization(stream, fmt):
+    # TODO (those vints are scary)
+    return {}
+
+
+READ_METADATA = {
+    0: read_validation,
+    1: read_compaction,
+    2: read_stats,
+    3: read_serialization,
+}
+
+
+def parse(data, sstable_format):
+    def read_metadata_offset(stream):
+        return (sstablelib.Stream.uint32, sstablelib.Stream.uint32)
+
+    offsets = sstablelib.Stream(data).array32(
+        sstablelib.Stream.instantiate(
+            sstablelib.Stream.tuple, sstablelib.Stream.uint32, sstablelib.Stream.uint32,
+        )
+    )
+
+    return {METADATA_TYPE_TO_NAME[typ]: READ_METADATA[typ](sstablelib.Stream(data, offset), sstable_format)
+            for typ, offset in offsets}
+
+
+def main():
+    cmdline_parser = argparse.ArgumentParser()
+    cmdline_parser.add_argument('stats_file', help='stats file to parse')
+    cmdline_parser.add_argument('-f', '--format', choices=['ka', 'la', 'mc'], default='mc', help='sstable format')
+
+    args = cmdline_parser.parse_args()
+
+    with open(args.stats_file, 'rb') as f:
+        data = f.read()
+
+    metadata = parse(data, args.format)
+
+    print(json.dumps(metadata, indent=4))
+
+
+if __name__ == '__main__':
+    main()

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -58,7 +58,12 @@ class Stream:
         self.offset += len
         return val
     def string16(self):
-        return self.bytes16().decode('utf-8')
+        buf = self.bytes16()
+        try:
+            return buf.decode('utf-8')
+        except UnicodeDecodeError:
+            # FIXME why are some strings unintelligible?
+            return 'INVALID(size={}, bytes={})'.format(len(buf), ''.join(map(lambda x: '{:02x}'.format(x), buf)))
     def map16(self, keytype=string16, valuetype=string16):
         return {self.keytype(): self.valuetype() for _ in range(self.int16())}
     def map32(self, keytype=string16, valuetype=string16):

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -18,9 +18,9 @@ class Stream:
         'd': 8, # double
     }
 
-    def __init__(self, data):
+    def __init__(self, data, offset=0):
         self.data = data
-        self.offset = 0
+        self.offset = offset
 
     def read(self, typ):
         try:

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -64,4 +64,4 @@ class Stream:
     def map32(self, keytype=string16, valuetype=string16):
         return {keytype(self): valuetype(self) for _ in range(self.int32())}
     def array32(self, valuetype):
-        return [valuetype() for _ in range(self.int32())]
+        return [valuetype(self) for _ in range(self.int32())]

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -79,3 +79,7 @@ class Stream:
         def instanciated_type(stream):
             return template_type(stream, *args)
         return instanciated_type
+
+
+def parse(stream, schema):
+    return {name: typ(stream) for name, typ in schema}

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -1,4 +1,3 @@
-import binascii
 import struct
 
 class Stream:

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -1,21 +1,41 @@
 import struct
 
 class Stream:
+    size = {
+        'c': 1, # char
+        'b': 1, # signed char (int8)
+        'B': 1, # unsigned char (uint8)
+        '?': 1, # bool
+        'h': 2, # short (int16)
+        'H': 2, # unsigned short (uint16)
+        'i': 4, # int (int32)
+        'I': 4, # unsigned int (uint32)
+        'l': 4, # long (int32)
+        'l': 4, # unsigned long (int32)
+        'q': 8, # long long (int64)
+        'Q': 8, # unsigned long long (uint64)
+        'f': 4, # float
+        'd': 8, # double
+    }
+
     def __init__(self, data):
         self.data = data
         self.offset = 0
+
+    def read(self, typ):
+        try:
+            (val,) = struct.unpack_from('>{}'.format(typ), self.data, self.offset)
+        except Exception as e:
+            raise ValueError('Failed to read type `{}\' from stream at offset {}: {}'.format(typ, e, self.offset))
+        self.offset += self.size[typ]
+        return val
+
     def int16(self):
-        (val,) = struct.unpack_from('>h', self.data, self.offset)
-        self.offset += 2
-        return val
+        return self.read('h')
     def int32(self):
-        (val,) = struct.unpack_from('>l', self.data, self.offset)
-        self.offset += 4
-        return val
+        return self.read('i')
     def int64(self):
-        (val,) = struct.unpack_from('>q', self.data, self.offset)
-        self.offset += 8
-        return val
+        return self.read('q')
     def bytes16(self):
         len = self.int16()
         val = self.data[self.offset:self.offset + len]

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -30,12 +30,28 @@ class Stream:
         self.offset += self.size[typ]
         return val
 
+    def bool(self):
+        return self.read('?')
+    def int8(self):
+        return self.read('b')
+    def uint8(self):
+        return self.read('B')
     def int16(self):
         return self.read('h')
+    def uint16(self):
+        return self.read('H')
     def int32(self):
         return self.read('i')
+    def uint32(self):
+        return self.read('I')
     def int64(self):
         return self.read('q')
+    def uint64(self):
+        return self.read('Q')
+    def float(self):
+        return self.read('f')
+    def double(self):
+        return self.read('d')
     def bytes16(self):
         len = self.int16()
         val = self.data[self.offset:self.offset + len]

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -70,3 +70,7 @@ class Stream:
         return {keytype(self): valuetype(self) for _ in range(self.int32())}
     def array32(self, valuetype):
         return [valuetype(self) for _ in range(self.int32())]
+    def tuple(self, *member_types):
+        return (mt(self) for mt in member_types)
+    def struct(self, *members):
+        return {member_name: member_type(self) for member_name, member_type in members}

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -74,3 +74,8 @@ class Stream:
         return (mt(self) for mt in member_types)
     def struct(self, *members):
         return {member_name: member_type(self) for member_name, member_type in members}
+    @staticmethod
+    def instantiate(template_type, *args):
+        def instanciated_type(stream):
+            return template_type(stream, *args)
+        return instanciated_type

--- a/sstablelib.py
+++ b/sstablelib.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import binascii
 import struct
 


### PR DESCRIPTION
Dump the contents of the sstable statistics file in a human-readable
form. Supports ka, la and mc format. Serialization header is not dumped
yet.