### PR TITLE
Introduce parser for scylla component files

### DIFF
--- a/sstable-scylla.py
+++ b/sstable-scylla.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sstable_tools.scylla
+
+
+cmdline_parser = argparse.ArgumentParser()
+cmdline_parser.add_argument('scylla_file', help='scylla component file to parse')
+cmdline_parser.add_argument('-f', '--format', choices=['ka', 'la', 'mc'], default='mc', help='sstable format')
+
+args = cmdline_parser.parse_args()
+
+with open(args.scylla_file, 'rb') as f:
+    data = f.read()
+
+metadata = sstable_tools.scylla.parse(data, args.format)
+
+print(json.dumps(metadata, indent=4))

--- a/sstable_tools/scylla.py
+++ b/sstable_tools/scylla.py
@@ -1,0 +1,52 @@
+import sstable_tools.sstablelib as sstablelib
+
+
+def parse(data, sstable_format):
+    disk_token_bound = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('exclusive', sstablelib.Stream.uint8),
+        ('token', sstablelib.Stream.string16),
+    )
+    disk_token_range = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('left', disk_token_bound),
+        ('right', disk_token_bound),
+    )
+    sharding_metadata = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('token_ranges', sstablelib.Stream.instantiate(sstablelib.Stream.array32, disk_token_range)),
+    )
+
+    sstable_enabled_features = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('enabled_features', sstablelib.Stream.uint64),
+    )
+
+    extension_attributes = sstablelib.Stream.instantiate(
+        sstablelib.Stream.map32, sstablelib.Stream.string32, sstablelib.Stream.string32,
+    )
+
+    UUID = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('msb', sstablelib.Stream.uint64),
+        ('lsb', sstablelib.Stream.uint64),
+    )
+    run_identifier = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('id', UUID),
+    )
+
+    scylla_component_data = sstablelib.Stream.instantiate(
+        sstablelib.Stream.set_of_tagged_union,
+        sstablelib.Stream.uint32,
+        (1, "sharding", sharding_metadata),
+        (2, "features", sstable_enabled_features),
+        (3, "extension_attributes", extension_attributes),
+        (4, "run_identifier", run_identifier),
+    )
+
+    schema = (
+        ('data', scylla_component_data),
+    )
+
+    return sstablelib.parse(sstablelib.Stream(data), schema)

--- a/sstable_tools/sstablelib.py
+++ b/sstable_tools/sstablelib.py
@@ -90,6 +90,19 @@ class Stream:
         return (mt(self) for mt in member_types)
     def struct(self, *members):
         return {member_name: member_type(self) for member_name, member_type in members}
+    def set_of_tagged_union(self, tag_type, *members):
+        members_by_keys = {k: (n, t) for k, n, t in members}
+        value = {}
+        for _ in range(tag_type(self)):
+            key = tag_type(self)
+            size = self.uint32()
+            if key in members_by_keys:
+                name, typ = members_by_keys[key]
+                value[name] = typ(self)
+                #TODO: check we haven't read more than size
+            else:
+                self.skip(size)
+        return value
     @staticmethod
     def instantiate(template_type, *args):
         def instanciated_type(stream):

--- a/sstable_tools/sstablelib.py
+++ b/sstable_tools/sstablelib.py
@@ -56,13 +56,15 @@ class Stream:
         return self.read('f')
     def double(self):
         return self.read('d')
-    def bytes16(self):
-        len = self.int16()
+    def bytes(self, len_type):
+        len = len_type(self)
         val = self.data[self.offset:self.offset + len]
         self.offset += len
         return val
-    def string16(self):
-        buf = self.bytes16()
+    def bytes16(self):
+        return self.bytes(Stream.uint16)
+    def string(self, len_type):
+        buf = self.bytes(len_type)
         try:
             return buf.decode('utf-8')
         except UnicodeDecodeError:
@@ -72,6 +74,8 @@ class Stream:
                 return 'INVALID(size={}, bytes={})'.format(len(buf), ''.join(map(lambda x: '{:02x}'.format(ord(x)), buf)))
             else:
                 return 'INVALID(size={}, bytes={})'.format(len(buf), ''.join(map(lambda x: '{:02x}'.format(x), buf)))
+    def string16(self):
+        return self.string(Stream.uint16)
     def map16(self, keytype=string16, valuetype=string16):
         return {self.keytype(): self.valuetype() for _ in range(self.int16())}
     def map32(self, keytype=string16, valuetype=string16):

--- a/sstable_tools/sstablelib.py
+++ b/sstable_tools/sstablelib.py
@@ -23,6 +23,9 @@ class Stream:
         self.data = data
         self.offset = offset
 
+    def skip(self, n):
+        self.offset += n
+
     def read(self, typ):
         try:
             (val,) = struct.unpack_from('>{}'.format(typ), self.data, self.offset)

--- a/sstable_tools/sstablelib.py
+++ b/sstable_tools/sstablelib.py
@@ -63,6 +63,8 @@ class Stream:
         return val
     def bytes16(self):
         return self.bytes(Stream.uint16)
+    def bytes32(self):
+        return self.bytes(Stream.uint32)
     def string(self, len_type):
         buf = self.bytes(len_type)
         try:
@@ -76,6 +78,8 @@ class Stream:
                 return 'INVALID(size={}, bytes={})'.format(len(buf), ''.join(map(lambda x: '{:02x}'.format(x), buf)))
     def string16(self):
         return self.string(Stream.uint16)
+    def string32(self):
+        return self.string(Stream.uint32)
     def map16(self, keytype=string16, valuetype=string16):
         return {self.keytype(): self.valuetype() for _ in range(self.int16())}
     def map32(self, keytype=string16, valuetype=string16):

--- a/sstable_tools/statistics.py
+++ b/sstable_tools/statistics.py
@@ -1,4 +1,3 @@
-import struct
 import sstable_tools.sstablelib as sstablelib
 
 


### PR DESCRIPTION
The parser follows the route set by the statistics component parser. A module in `sstable_tools` providing an python API to parse the file, and a script wrapper `sstable-scylla.py`, that uses said API.