### PR TITLE
statistics: ancestors were removed in mc format

### DIFF
--- a/sstable_tools/statistics.py
+++ b/sstable_tools/statistics.py
@@ -22,10 +22,10 @@ def read_validation(stream, fmt):
 
 def read_compaction(stream, fmt):
     ka_la_schema = (
+        ('ancestors', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.uint32)),
         ('cardinality', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.uint8)),
     )
     mc_schema = (
-        ('ancestors', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.uint32)),
         ('cardinality', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.uint8)),
     )
 


### PR DESCRIPTION
And they exist only in older sstable formats.
The actual implementation was reversed: available only in mc.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>