### PR TITLE
sstable-scylla: Support large_data stats

### DIFF
--- a/sstable-scylla.py
+++ b/sstable-scylla.py
@@ -7,7 +7,7 @@ import sstable_tools.scylla
 
 cmdline_parser = argparse.ArgumentParser()
 cmdline_parser.add_argument('scylla_file', help='scylla component file to parse')
-cmdline_parser.add_argument('-f', '--format', choices=['ka', 'la', 'mc'], default='mc', help='sstable format')
+cmdline_parser.add_argument('-f', '--format', choices=['ka', 'la', 'mc', 'md'], default='md', help='sstable format')
 
 args = cmdline_parser.parse_args()
 

--- a/sstable_tools/scylla.py
+++ b/sstable_tools/scylla.py
@@ -36,6 +36,23 @@ def parse(data, sstable_format):
         ('id', UUID),
     )
 
+    large_data_type = sstablelib.Stream.instantiate(
+        sstablelib.Stream.enum32,
+        (1, "partition_size"),
+        (2, "row_size"),
+        (3, "cell_size"),
+        (4, "rows_in_partition"),
+    )
+    large_data_stats_entry = sstablelib.Stream.instantiate(
+        sstablelib.Stream.struct,
+        ('max_value', sstablelib.Stream.uint64),
+        ('threshold', sstablelib.Stream.uint64),
+        ('above_threshold', sstablelib.Stream.uint32),
+    )
+    large_data_stats = sstablelib.Stream.instantiate(
+        sstablelib.Stream.map32, large_data_type, large_data_stats_entry,
+    )
+
     scylla_component_data = sstablelib.Stream.instantiate(
         sstablelib.Stream.set_of_tagged_union,
         sstablelib.Stream.uint32,
@@ -43,6 +60,7 @@ def parse(data, sstable_format):
         (2, "features", sstable_enabled_features),
         (3, "extension_attributes", extension_attributes),
         (4, "run_identifier", run_identifier),
+        (5, "large_data_stats", large_data_stats),
     )
 
     schema = (

--- a/sstable_tools/sstablelib.py
+++ b/sstable_tools/sstablelib.py
@@ -103,6 +103,10 @@ class Stream:
             else:
                 self.skip(size)
         return value
+    def enum32(self, *values):
+        d = {v: n for v, n in values}
+        return d[self.uint32()]
+
     @staticmethod
     def instantiate(template_type, *args):
         def instanciated_type(stream):

--- a/sstable_tools/statistics.py
+++ b/sstable_tools/statistics.py
@@ -1,4 +1,5 @@
 import sstable_tools.sstablelib as sstablelib
+import re
 
 
 METADATA_TYPE_TO_NAME = {
@@ -28,7 +29,7 @@ def read_compaction(stream, fmt):
         ('cardinality', sstablelib.Stream.instantiate(sstablelib.Stream.array32, sstablelib.Stream.uint8)),
     )
 
-    if fmt == 'mc':
+    if re.match('m[cd]', fmt):
         return sstablelib.parse(stream, mc_schema)
     else:
         return sstablelib.parse(stream, ka_la_schema)
@@ -105,7 +106,7 @@ def read_stats(stream, fmt):
         ('commitlog_intervals', sstablelib.Stream.instantiate(sstablelib.Stream.array32, commitlog_interval)),
     )
 
-    if fmt == 'mc':
+    if re.match('m[cd]', fmt):
         return sstablelib.parse(stream, mc_schema)
     else:
         return sstablelib.parse(stream, ka_la_schema)


### PR DESCRIPTION
large_data_stats are available in scylla version 4.4
scylladb/scylla@77466177abec701186ed7241e7e66146f853d16e
    
Example output:
```
$ ./sstable-scylla.py ~/.dtest/dtest-vy6qhe8u/test/node1/data/ks/t-4e0655605e7311eb98c7ef4c4fbbeed1/md-17-big-Scylla.db | head -24
{
    "data": {
        "large_data_stats": {
            "rows_in_partition": {
                "max_value": 1,
                "threshold": 100000,
                "above_threshold": 0
            },
            "cell_size": {
                "max_value": 8,
                "threshold": 1048576,
                "above_threshold": 0
            },
            "row_size": {
                "max_value": 27,
                "threshold": 10485760,
                "above_threshold": 0
            },
            "partition_size": {
                "max_value": 46,
                "threshold": 1048576000,
                "above_threshold": 0
            }
        },
```
